### PR TITLE
Improve plot_matrix performance

### DIFF
--- a/event_types/event_types.py
+++ b/event_types/event_types.py
@@ -1501,7 +1501,7 @@ def plot_test_vs_predict(dtf_e_test, trained_models, trained_model_name):
     return plt
 
 
-def plot_matrix(dtf, train_features, labels, n_types=2):
+def plot_matrix(dtf, train_features, labels, n_types=2, plot_events=20000):
     '''
     Plot a matrix of each variable in train_features against another (not all combinations).
     The data is divided to n_types bins of equal statistics based on the labels.
@@ -1519,8 +1519,9 @@ def plot_matrix(dtf, train_features, labels, n_types=2):
     labels: str
         Name of the variable used as the labels in the training.
     n_types: int (default=2)
-            The number of types to divide the data in.
-
+        The number of types to divide the data in.
+    plot_events: int (default=20000)
+        For efficiency, limit the number of events that will be used for the plots
 
     Returns
     -------
@@ -1529,8 +1530,12 @@ def plot_matrix(dtf, train_features, labels, n_types=2):
 
     setStyle()
 
-    dtf = add_event_type_column(dtf, labels, n_types)
+    # Check if event_type column already present within dtf:
+    if "event_type" not in dtf.columns:
+        dtf = add_event_type_column(dtf, labels, n_types)
 
+    # Mask out the events without a clear event type
+    dtf = dtf[dtf['event_type'] > 0]
     type_colors = {
         1: "#ba2c54",
         2: "#5B90DC",
@@ -1546,14 +1551,13 @@ def plot_matrix(dtf, train_features, labels, n_types=2):
     for these_vars in vars_to_plot:
         grid_plots.append(
             sns.pairplot(
-                dtf,
+                dtf.sample(n=plot_events),
                 vars=these_vars,
                 hue='event_type',
                 palette=type_colors,
                 corner=True
             )
         )
-
     return grid_plots
 
 

--- a/scripts/export_event_types.py
+++ b/scripts/export_event_types.py
@@ -30,8 +30,11 @@ if __name__ == '__main__':
 
     trained_model = event_types.load_models([selected_model])
     # Get the energy binning from the trained model
+    e_ranges = list(trained_model[next(iter(trained_model))].keys())
+    # Sometimes they do not come in order... Here we fix that case.
+    e_ranges.sort()
     log_e_reco_bins = np.log10(
-        event_types.extract_energy_bins(trained_model[next(iter(trained_model))].keys())
+        event_types.extract_energy_bins(e_ranges)
     )
 
     # This variable will store the event type partitioning container.
@@ -98,6 +101,16 @@ if __name__ == '__main__':
             dtf.loc[dtf_e_test[energy_key].index.values, 'event_type'] = (
                 d_types[selected_model][energy_key]['reco']
             )
+        # labels, train_features = event_types.nominal_labels_train_features()
+        # plot_list = event_types.plot_matrix(dtf, train_features, labels, n_types=3, plot_events=20000)
+        # for i, plot in enumerate(plot_list):
+        #     if "gamma" in dl2_file:
+        #         plot.savefig("gamma_features_{}.pdf".format(i))
+        #     elif "proton" in dl2_file:
+        #         plot.savefig("proton_features_{}.pdf".format(i))
+        #     elif "electron" in dl2_file:
+        #         plot.savefig("electron_features_{}.pdf".format(i))
+
         print("A total of {} events will be written.".format(len(dtf['event_type'])))
         print("A total of {} events were set as -99...".format(len(dtf[dtf['event_type'] == -99])))
 

--- a/scripts/reduce_data.py
+++ b/scripts/reduce_data.py
@@ -15,8 +15,14 @@ if __name__ == '__main__':
     dl2_file_list = [
                      # 'electron_onSource.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-0.root',
                      # 'proton_onSource.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-0.root',
-                     'gamma_onSource.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-0.root',
-                    ]
+                     # 'gamma_onSource.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-0.root',
+                     'gamma_cone.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-0.root',
+                     # 'gamma_cone.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-1.root',
+                     # 'gamma_cone.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-2.root',
+                     # 'gamma_cone.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-3.root',
+                     # 'gamma_cone.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-4.root',
+                     # 'gamma_cone.S.BL-4LSTs25MSTs70SSTs-MSTF_ID0.eff-5.root',
+    ]
     dl2_file_path = (
         '/lustre/fs22/group/cta/users/maierg/analysis/'
         'AnalysisData/prod5-Paranal-20deg-sq10-LL/EffectiveAreas/'


### PR DESCRIPTION
Hi Orel, 

A couple of minor changes to allow the use of plot_matrix with a constrained number of entries.

I added the code to plot them into the export_event_types script, although I left it commented as it slows down the production, and we might not always want to produce the plots.

Although I will produce the plot to compare cone gammas and electrons/protons...