### PR TITLE
Testing true ets

### DIFF
--- a/event_types/event_types.py
+++ b/event_types/event_types.py
@@ -2159,3 +2159,42 @@ def plot_1d_confusion_matrix(event_types, trained_model_name, n_types=2):
     plt.tight_layout()
 
     return plt
+
+
+def plot_event_type_distribution(event_types, label, n_types=3):
+    """
+    Plot the distribution of the event types for a given dataframe.
+
+    Parameters
+    ----------
+    event_types: column of a pandas DataFrame or list of columns
+        The column(s) containing the event types.
+    label: str or list of str
+        The label for the legend associated to each DataFrame.
+    n_types: int (default=3)
+        The number of event types in which the data is divided.
+
+    Returns
+    -------
+    A pyplot instance with the event type distribution plot.
+    """
+
+    setStyle()
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+
+    ax.hist(
+        event_types,
+        bins=np.arange(0.5, n_types + 1.5, 1),
+        histtype="bar",
+        label=label,
+    )
+
+    ax.set_xlabel("Event type")
+    ax.set_ylabel("Number of events")
+    ax.set_xticks(np.arange(1, n_types + 1, 1))
+    ax.set_xticklabels(np.arange(1, n_types + 1, 1))
+    ax.legend()
+    plt.tight_layout()
+
+    return plt

--- a/event_types/event_types.py
+++ b/event_types/event_types.py
@@ -1482,6 +1482,8 @@ def partition_event_types(
             keys=energy ranges, values=3rd dict
         3rd dict:
             keys=offset ranges, values=partition values array
+    save_true_types: Bool (default=False)
+        If true, the true event types will be saved into the dataframe.
     Returns
     -------
     event_types: nested dict

--- a/event_types/event_types.py
+++ b/event_types/event_types.py
@@ -1542,6 +1542,7 @@ def partition_event_types(
                 event_types[model_name][this_e_range][this_offset_range] = defaultdict(list)
 
                 event_types_bins = mstats.mquantiles(dtf_this_e_offset["y_pred"], type_bins)
+                event_types_bins_true = mstats.mquantiles(dtf_this_e_offset[labels].values, type_bins)
 
                 # If return_partition is True, then store the event type bins into the container.
                 if return_partition:
@@ -1562,7 +1563,7 @@ def partition_event_types(
                     )
 
                 for this_value in dtf_this_e_offset[labels].values:
-                    this_event_type = np.searchsorted(event_types_bins, this_value)
+                    this_event_type = np.searchsorted(event_types_bins_true, this_value)
                     if this_event_type < 1:
                         this_event_type = 1
                     if this_event_type > n_types:

--- a/scripts/export_event_types.py
+++ b/scripts/export_event_types.py
@@ -122,10 +122,15 @@ if __name__ == "__main__":
                     dtf.loc[dtf_e_train[energy_key].index.values, "true_event_type"] = -1
 
         dtf.loc[dtf_test[suffix].index.values, "event_type"] = dtf_test[suffix]["event_type"]
+        # Assign true event types as calculated for gammas, but not for protons and electrons, which should be random.
         if true_event_types:
-            dtf.loc[dtf_test[suffix].index.values, "true_event_type"] = dtf_test[suffix][
-                "true_event_type"
-            ]
+            if particle is gamma:
+                dtf.loc[dtf_test[suffix].index.values, "true_event_type"] = dtf_test[suffix][
+                    "true_event_type"
+                ]
+            else:
+                # Assign random true event types for protons and electrons. Possible values are from 1 to n_types.
+                dtf["true_event_type"] = np.random.randint(1, n_types + 1, size=len(dtf))
 
         print("A total of {} events will be written.".format(len(dtf["event_type"])))
         dtf_7 = dtf[dtf["cut_class"] != 7]

--- a/scripts/export_event_types.py
+++ b/scripts/export_event_types.py
@@ -108,7 +108,6 @@ if __name__ == "__main__":
                 n_offset_bins=n_offset_bins,
                 n_types=n_types,
                 event_type_bins=event_type_partition,
-                save_true_types=true_event_types,
             )
 
         # Start creating the event_type column within the original dataframe,
@@ -126,15 +125,15 @@ if __name__ == "__main__":
                     dtf.loc[dtf_e_train[energy_key].index.values, "true_event_type"] = -1
 
         dtf.loc[dtf_test[suffix].index.values, "event_type"] = dtf_test[suffix]["event_type"]
-        # Assign true event types as calculated for gammas, but not for protons and electrons, which should be random.
+        # Assign true event types as calculated for gammas. For protons and electrons, assign the same as reco.
         if true_event_types:
             if particle is gamma:
                 dtf.loc[dtf_test[suffix].index.values, "true_event_type"] = dtf_test[suffix][
                     "true_event_type"
                 ]
             else:
-                # Assign random true event types for protons and electrons. Possible values are from 1 to n_types.
-                dtf["true_event_type"] = np.random.randint(1, n_types + 1, size=len(dtf))
+                # For protons and electrons, assume same event types for reco and true.
+                dtf["true_event_type"] = dtf["event_type"]
 
         print("A total of {} events will be written.".format(len(dtf["event_type"])))
         dtf_7 = dtf[dtf["cut_class"] != 7]

--- a/scripts/export_event_types.py
+++ b/scripts/export_event_types.py
@@ -1,6 +1,8 @@
 import argparse
 
 import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
 
 from event_types import event_types
 
@@ -52,6 +54,8 @@ if __name__ == "__main__":
     event_type_partition = None
     # Option to get true event types.
     true_event_types = True
+    # Option to plot event types distributions.
+    plot_event_types = True
 
     for particle in particles:
         print("Exporting files: {}".format(particle))
@@ -156,6 +160,30 @@ if __name__ == "__main__":
                         np.sum(dtf_7["true_event_type"] == event_type), event_type
                     )
                 )
+
+        if plot_event_types:
+            Path("plots").mkdir(parents=True, exist_ok=True)
+            # Plot and save the event type distributions.
+            if true_event_types:
+                distribution = event_types.plot_event_type_distribution(
+                    [dtf["event_type"], dtf_7["event_type"], dtf["true_event_type"], dtf_7["true_event_type"]],
+                    label=["all", "gamma-like", "all true", "gamma-like true"],
+                    n_types=n_types,
+                )
+            else:
+                distribution = event_types.plot_event_type_distribution(
+                    [dtf["event_type"], dtf_7["event_type"]], label=["all", "gamma-like"], n_types=n_types
+                )
+
+            if particle is gamma:
+                plt.title("Event type distribution: Gammas")
+                plt.savefig("plots/event_type_distribution_gamma.pdf")
+            elif particle is electron:
+                plt.title("Event type distribution: Electrons")
+                plt.savefig("plots/event_type_distribution_electron.pdf")
+            elif particle is proton:
+                plt.title("Event type distribution: Protons")
+                plt.savefig("plots/event_type_distribution_proton.pdf")
 
         # Summary:
         # Types 1, 2 and 3 are actual reconstructed event types, where 1 is the best type and


### PR DESCRIPTION
These changes have been made with the purpose to test the calculation of true event types and try to make it more realistic. While doing this, 2 things have been noticed:
1) The partition of true event types should be independent from the actual partition, as we want to use true event types to test the room for improvement of the whole process.
2) True event types are not correctly defined for the background. We know that the direction is never well reconstructed for the background, as the previous analysis only expects it to be good for gammas. This means that partitioning true event types for background (by true misdirection) always ends up sending most of the background to the worst type, which affects heavily to the event-type-wise sensitivity computation, among others.

Both things have been fixed. The first one by having two partition matrices, one for reco and one for true. The second one by assuming the reconstructed event types for the background are good enough to use them directly as true event types (it seems not optimal, but without a definition, this is the best we can do to be able to compute realistic IRFs with "almost" true event types).