### PR TITLE
Random event types

### DIFF
--- a/scripts/control_plots.py
+++ b/scripts/control_plots.py
@@ -31,7 +31,9 @@ if __name__ == "__main__":
     Path("plots/matrices").mkdir(parents=True, exist_ok=True)
     Path("plots/pearson").mkdir(parents=True, exist_ok=True)
 
-    for this_e_range, this_dtf in dtf_e.items():
+    for this_e_range, this_dic in dtf_e.items():
+        # Select the dtf for the first entry in the dictionary (there is only one entry for offset angle)
+        this_dtf = this_dic[list(this_dic.keys())[0]]
 
         e_range_name = this_e_range.replace(" < ", "-").replace(" ", "_")
 

--- a/scripts/randomize_event_types.py
+++ b/scripts/randomize_event_types.py
@@ -5,8 +5,9 @@ import numpy as np
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
-        description="Change the order of all (positive) event types at random. This is useful to test if the"
+        description="Randomize the event types. This is useful to test if the"
                     "performance of joint random event types is the same as not using event types."
+                    "This can only be used for equal-statistic partitions of event types."
     )
 
     args = parser.parse_args()
@@ -14,20 +15,23 @@ if __name__ == "__main__":
     layout_desc = "N.D25-4LSTs09MSTs-MSTN"  # LaPalma
     # layout_desc = 'S-M6C8aj-14MSTs37SSTs-MSTF'  # Paranal
 
+    n_types = 3
+
     particles = ["gamma_cone", "electron", "proton"]
 
     for particle in particles:
+        # It is necessary to start from a real ETs file to be able to take into account the negative
+        # values, which should not change and are the same independently of the partition. Any .txt
+        # file output from export_event_types.py will be good, even if the number of ETs is different.
+    	
         # Read the event types from the file
         event_types = np.loadtxt(f"{particle}.{layout_desc}_ID0.txt")
 
-        # Mask the negative values
-        event_types_pos = event_types[event_types > 0]
-
-        # Randomize the event types
-        np.random.shuffle(event_types_pos)
+        # Randomize the positive event types, assigning random values from 1 to n_types
+        event_types_pos = np.random.randint(1, n_types + 1, size=len(event_types[event_types > 0]))
 
         # Fill the original arrays with the randomized event types
         event_types[event_types > 0] = event_types_pos
 
         # Save the randomized event types
-        np.savetxt(f"{particle}.{layout_desc}_ID0_random.txt", event_types, fmt="%d")
+        np.savetxt(f"{particle}.{layout_desc}_ID0_{n_types}types_random.txt", event_types, fmt="%d")

--- a/scripts/randomize_event_types.py
+++ b/scripts/randomize_event_types.py
@@ -1,0 +1,33 @@
+import argparse
+
+import numpy as np
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Change the order of all (positive) event types at random. This is useful to test if the"
+                    "performance of joint random event types is the same as not using event types."
+    )
+
+    args = parser.parse_args()
+
+    layout_desc = "N.D25-4LSTs09MSTs-MSTN"  # LaPalma
+    # layout_desc = 'S-M6C8aj-14MSTs37SSTs-MSTF'  # Paranal
+
+    particles = ["gamma_cone", "electron", "proton"]
+
+    for particle in particles:
+        # Read the event types from the file
+        event_types = np.loadtxt(f"{particle}.{layout_desc}_ID0.txt")
+
+        # Mask the negative values
+        event_types_pos = event_types[event_types > 0]
+
+        # Randomize the event types
+        np.random.shuffle(event_types_pos)
+
+        # Fill the original arrays with the randomized event types
+        event_types[event_types > 0] = event_types_pos
+
+        # Save the randomized event types
+        np.savetxt(f"{particle}.{layout_desc}_ID0_random.txt", event_types, fmt="%d")


### PR DESCRIPTION
Add a tool to randomize the event types after they are calculated from export_event_types.py.
This is needed to test if the results of a joint analysis of random event types (they should all have statistically the same permormance) match the results of a standard analysis, as we understand it should.